### PR TITLE
Correct url of repository after repository relocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/ramya-rao-a/vscode-emmet.git"
+        "url": "https://github.com/Microsoft/vscode-emmet"
     },
     "activationEvents": [
         "onLanguage:html",


### PR DESCRIPTION
## Changelog

  * Correct url of repository after repository relocation to Microsoft scope