### PR TITLE
Dynamic registration of supported language modes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,48 +23,48 @@ const JSX_MODE: vscode.DocumentFilter = { language: 'javascriptreact', scheme: '
 const TSX_MODE: vscode.DocumentFilter = { language: 'typescriptreact', scheme: 'file' };
 
 export function activate(context: vscode.ExtensionContext) {
-  let completionProvider = new EmmetCompletionItemProvider();
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(HTML_MODE, completionProvider, '!', '.'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(JADE_MODE, completionProvider, '!', '.'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SLIM_MODE, completionProvider, '!', '.'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(HAML_MODE, completionProvider, '!', '.'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(XML_MODE, completionProvider, '.'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(XSL_MODE, completionProvider, '.'));
+    let completionProvider = new EmmetCompletionItemProvider();
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(HTML_MODE, completionProvider, '!', '.'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(JADE_MODE, completionProvider, '!', '.'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SLIM_MODE, completionProvider, '!', '.'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(HAML_MODE, completionProvider, '!', '.'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(XML_MODE, completionProvider, '.'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(XSL_MODE, completionProvider, '.'));
 
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(CSS_MODE, completionProvider, ':'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SCSS_MODE, completionProvider, ':'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SASS_MODE, completionProvider, ':'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(LESS_MODE, completionProvider, ':'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(STYLUS_MODE, completionProvider, ':'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(CSS_MODE, completionProvider, ':'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SCSS_MODE, completionProvider, ':'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SASS_MODE, completionProvider, ':'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(LESS_MODE, completionProvider, ':'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(STYLUS_MODE, completionProvider, ':'));
 
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(JSX_MODE, completionProvider, '.'));
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(TSX_MODE, completionProvider, '.'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(JSX_MODE, completionProvider, '.'));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(TSX_MODE, completionProvider, '.'));
 
-  context.subscriptions.push(vscode.commands.registerCommand('emmet.wrapWithAbbreviation', () => {
-    wrapWithAbbreviation();
-  }));
+    context.subscriptions.push(vscode.commands.registerCommand('emmet.wrapWithAbbreviation', () => {
+        wrapWithAbbreviation();
+    }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('emmet.expandAbbreviation', () => {
-    expandAbbreviation();
-  }));
+    context.subscriptions.push(vscode.commands.registerCommand('emmet.expandAbbreviation', () => {
+        expandAbbreviation();
+    }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('emmet.removeTag', () => {
-    removeTag();
-  }));
+    context.subscriptions.push(vscode.commands.registerCommand('emmet.removeTag', () => {
+        removeTag();
+    }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('emmet.updateTag', () => {
-    vscode.window.showInputBox({prompt: 'Enter Tag'}).then(tagName => {
-      updateTag(tagName);
-    });
-  }));
+    context.subscriptions.push(vscode.commands.registerCommand('emmet.updateTag', () => {
+        vscode.window.showInputBox({prompt: 'Enter Tag'}).then(tagName => {
+            updateTag(tagName);
+        });
+    }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('emmet.matchTag', () => {
-      matchTag();
-  }));
+    context.subscriptions.push(vscode.commands.registerCommand('emmet.matchTag', () => {
+        matchTag();
+    }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('emmet.balanceOut', () => {
-      balanceOut();
-  }));
+    context.subscriptions.push(vscode.commands.registerCommand('emmet.balanceOut', () => {
+        balanceOut();
+    }));
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,37 +8,38 @@ import { updateTag } from './updateTag';
 import { matchTag } from './matchTag';
 import { balanceOut } from './balance';
 
-const HTML_MODE: vscode.DocumentFilter = { language: 'html', scheme: 'file' };
-const JADE_MODE: vscode.DocumentFilter = { language: 'jade', scheme: 'file' };
-const SLIM_MODE: vscode.DocumentFilter = { language: 'slim', scheme: 'file' };
-const HAML_MODE: vscode.DocumentFilter = { language: 'haml', scheme: 'file' };
-const XML_MODE: vscode.DocumentFilter = { language: 'xml', scheme: 'file' };
-const XSL_MODE: vscode.DocumentFilter = { language: 'xsl', scheme: 'file' };
-const CSS_MODE: vscode.DocumentFilter = { language: 'css', scheme: 'file' };
-const SCSS_MODE: vscode.DocumentFilter = { language: 'scss', scheme: 'file' };
-const SASS_MODE: vscode.DocumentFilter = { language: 'sass', scheme: 'file' };
-const LESS_MODE: vscode.DocumentFilter = { language: 'less', scheme: 'file' };
-const STYLUS_MODE: vscode.DocumentFilter = { language: 'stylus', scheme: 'file' };
-const JSX_MODE: vscode.DocumentFilter = { language: 'javascriptreact', scheme: 'file' };
-const TSX_MODE: vscode.DocumentFilter = { language: 'typescriptreact', scheme: 'file' };
+interface ISupportedLanguageMode {
+    id: string;
+    triggerCharacters: string[];
+}
+
+const SUPPORTED_LANGUAGE_MODES: ISupportedLanguageMode[] = [
+    { id: 'html', triggerCharacters: ['!', '.'] },
+    { id: 'jade', triggerCharacters: ['!', '.'] },
+    { id: 'slim', triggerCharacters: ['!', '.'] },
+    { id: 'haml', triggerCharacters: ['!', '.'] },
+    { id: 'xml', triggerCharacters: ['.'] },
+    { id: 'xsl', triggerCharacters: ['.'] },
+
+    { id: 'css', triggerCharacters: [':'] },
+    { id: 'scss', triggerCharacters: [':'] },
+    { id: 'sass', triggerCharacters: [':'] },
+    { id: 'less', triggerCharacters: [':'] },
+    { id: 'stylus', triggerCharacters: [':'] },
+
+    { id: 'javascriptreact', triggerCharacters: ['.'] },
+    { id: 'typescriptreact', triggerCharacters: ['.'] }
+];
 
 export function activate(context: vscode.ExtensionContext) {
     let completionProvider = new EmmetCompletionItemProvider();
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(HTML_MODE, completionProvider, '!', '.'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(JADE_MODE, completionProvider, '!', '.'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SLIM_MODE, completionProvider, '!', '.'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(HAML_MODE, completionProvider, '!', '.'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(XML_MODE, completionProvider, '.'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(XSL_MODE, completionProvider, '.'));
 
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(CSS_MODE, completionProvider, ':'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SCSS_MODE, completionProvider, ':'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(SASS_MODE, completionProvider, ':'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(LESS_MODE, completionProvider, ':'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(STYLUS_MODE, completionProvider, ':'));
+    for (let language of SUPPORTED_LANGUAGE_MODES) {
+        const selector: vscode.DocumentFilter = { language: language.id, scheme: 'file' };
+        const provider = vscode.languages.registerCompletionItemProvider(selector, completionProvider, ...language.triggerCharacters);
 
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(JSX_MODE, completionProvider, '.'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(TSX_MODE, completionProvider, '.'));
+        context.subscriptions.push(provider);
+    }
 
     context.subscriptions.push(vscode.commands.registerCommand('emmet.wrapWithAbbreviation', () => {
         wrapWithAbbreviation();


### PR DESCRIPTION
## Description

As i see, you use constants for registration of supported modes. Now it looks incorrect and applicable for the concept of the cycle.

You can close this PR, because it's dispute about tastes 🌵 

## Changelog

  * Use 4 spaces for indentation in `extension.ts` as in other files
  * Dynamic registration of supported language modes instead of constants