### PR TITLE
Add language javascript to activationEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "onLanguage:sass",
         "onLanguage:less",
         "onLanguage:stylus",
+        "onLanguage:javascript",
         "onLanguage:javascriptreact",
         "onLanguage:typescriptreact"
     ],


### PR DESCRIPTION
Hello, I'm opening this PR to add `javascript` to the list of languages this extension is activated for. I am guessing that JS was purposely left out as typically only JS+React would include HTML or CSS.

However, members of the Ember community are moving towards single file components using this extension: https://marketplace.visualstudio.com/items?itemName=dhedgecock.ember-syntax

The language created by that extension used the id `javascript`. Originally it was `javascriptextended`, but this created issues because many of the VSCode extensions are only activated for `javascript` or `javascriptreact`, so we switched it to `javascript`.

If there is a better way to handle this please let me know!